### PR TITLE
Warning, empty second argument is needed for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Create the following mapping for headers in LemonLDAP::NG:
  * Auth-User => $uid
  * Auth-Cn => $cn
  * Auth-Mail => $mail
- * Auth-Groups => encode_base64($groups)
+ * Auth-Groups => encode_base64($groups,"")
 


### PR DESCRIPTION
Hello,
the second empty argument is needed for encode_base64, else some headers may be lost